### PR TITLE
fix: P1 — consistent effectful op contract for read_file/http_get (#23)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -198,6 +198,10 @@ Use `assign` to update a previously declared mutable variable.
 ```
 
 Effectful operations are a compile error if the corresponding effect is not declared in the function's `effects` list.
+Each effectful operation must include an explicit `effect` field with the canonical value:
+- `print` must declare `"effect": "IO"`
+- `read_file` must declare `"effect": "FS"`
+- `http_get` must declare `"effect": "NET"`
 `print` expects a `String` argument.
 
 ---

--- a/interpreter/checker.py
+++ b/interpreter/checker.py
@@ -357,6 +357,9 @@ class Checker:
 
             elif op == "read_file":
                 # L2: requires FS effect; "path" must be string; result stored via let
+                eff = stmt.get("effect")
+                if eff != "FS":
+                    raise CheckError(f"[{fn_id}] 'read_file' must declare effect: FS")
                 if "FS" not in self.declared_effects:
                     raise NailEffectError(
                         f"[{fn_id}] 'read_file' uses FS effect, but function does not declare it"
@@ -372,6 +375,9 @@ class Checker:
 
             elif op == "http_get":
                 # L2: requires NET effect; "url" must be string; result stored via 'into'
+                eff = stmt.get("effect")
+                if eff != "NET":
+                    raise CheckError(f"[{fn_id}] 'http_get' must declare effect: NET")
                 if "NET" not in self.declared_effects:
                     raise NailEffectError(
                         f"[{fn_id}] 'http_get' uses NET effect, but function does not declare it"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -190,6 +190,73 @@ class TestL2Effects(unittest.TestCase):
             Checker(spec).check()
 
 
+class TestEffectfulOpContract(unittest.TestCase):
+
+    def test_read_file_with_effect_declared_happy_path(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "read_file", "path": {"lit": "/tmp/demo.txt"}, "effect": "FS", "into": "contents"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["FS"])
+        Checker(spec).check()
+
+    def test_http_get_with_effect_declared_happy_path(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "http_get", "url": {"lit": "https://example.com"}, "effect": "NET", "into": "body"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["NET"])
+        Checker(spec).check()
+
+    def test_read_file_without_effect_field_fails(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "read_file", "path": {"lit": "/tmp/demo.txt"}},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["FS"])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_http_get_without_effect_field_fails(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "http_get", "url": {"lit": "https://example.com"}},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["NET"])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_read_file_operand_type_validation(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "read_file", "path": {"lit": 123}, "effect": "FS"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["FS"])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_http_get_operand_type_validation(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "http_get", "url": {"lit": True}, "effect": "NET"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["NET"])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_read_file_deferred_runtime_error_is_stable(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "read_file", "path": {"lit": "/tmp/demo.txt"}, "effect": "FS"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["FS"])
+        Checker(spec).check()
+        with self.assertRaisesRegex(NailRuntimeError, r"'read_file' is recognized by the checker but not yet executed"):
+            Runtime(spec).run()
+
+    def test_http_get_deferred_runtime_error_is_stable(self):
+        spec = fn_spec("f", [], UNIT_T, [
+            {"op": "http_get", "url": {"lit": "https://example.com"}, "effect": "NET"},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ], effects=["NET"])
+        Checker(spec).check()
+        with self.assertRaisesRegex(NailRuntimeError, r"'http_get' is recognized by the checker but not yet executed"):
+            Runtime(spec).run()
+
+
 class TestFunctionCalls(unittest.TestCase):
 
     def test_pure_calls_pure_ok(self):


### PR DESCRIPTION
## Summary
Closes #23

Enforces the same explicit `effect` field requirement on `read_file` and `http_get` that `print` already has — making effectful op policy consistent across the board.

## Changes
- **checker.py**: `read_file` now requires an explicit `effect` field (FS); `http_get` requires Net. Missing field → `CheckError`.
- **SPEC.md**: Effectful op metadata policy documented formally.
- **tests/test_interpreter.py**: 8 new focused tests
  - happy-path with effect declared ✅
  - missing effect field → CheckError ✅
  - operand type validation (path/url must be string) ✅
  - stable deferred runtime error contract ✅

## Test Results
102 tests passing (was 94).