### PR TITLE
feat: v0.4 — Collection Type Operations (#26)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -237,6 +237,21 @@ Each effectful operation must include an explicit `effect` field with the canoni
 - `float_to_str(Float) -> String` — Convert float to string
 - `bool_to_str(Bool) -> String` — Convert boolean to string
 
+### Collection Operations (v0.4)
+```json
+{ "op": "list_get",  "list": <var>, "index": <expr> }
+{ "op": "list_push", "list": <var>, "value": <expr> }
+{ "op": "list_len",  "list": <var> }
+{ "op": "map_get",   "map": <var>,  "key": <expr> }
+```
+
+Rules:
+- `list_get`: `list` must be `list<T>`, `index` must be `int`; returns `T`.
+  Out-of-bounds is a runtime error.
+- `list_push`: `list` must be `list<T>`, `value` must be `T`; mutates in place; returns `unit`.
+- `list_len`: `list` must be `list<T>`; returns `int`.
+- `map_get`: `map` must be `map<K, V>`, `key` must be `K`; returns `V`.
+
 ### Overflow Policy (v0.3)
 - **Type-level**: Only `"overflow": "panic"` is valid in type declarations. This is the default.
 - **Expression-level** (v0.3): Per-operation `"overflow"` field overrides the type default:

--- a/interpreter/checker.py
+++ b/interpreter/checker.py
@@ -11,7 +11,7 @@ from typing import Any
 from .types import (
     NailType, NailTypeError, NailEffectError,
     parse_type, types_equal,
-    IntType, FloatType, BoolType, StringType, UnitType, OptionType, ResultType,
+    IntType, FloatType, BoolType, StringType, UnitType, OptionType, ResultType, ListType, MapType,
     VALID_EFFECTS,
 )
 
@@ -566,6 +566,10 @@ class Checker:
                 # Call can be used as a statement (discard return value)
                 self._check_op_expr(fn_id, stmt, local_env)
 
+            elif op == "list_push":
+                # list_push mutates and returns unit; valid as statement
+                self._check_op_expr(fn_id, stmt, local_env)
+
             elif op == "if":
                 cond_type = self._check_expr(fn_id, stmt.get("cond"), local_env)
                 if not isinstance(cond_type, BoolType):
@@ -737,6 +741,56 @@ class Checker:
             if not isinstance(l_type, StringType) or not isinstance(r_type, StringType):
                 raise CheckError(f"[{fn_id}] 'concat' requires two strings, got {l_type} and {r_type}")
             return StringType()
+
+        # Collection ops (v0.4)
+        elif op == "list_get":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise CheckError(f"[{fn_id}] 'list_get.list' must be a variable reference")
+            list_type = self._check_expr(fn_id, list_expr, env)
+            if not isinstance(list_type, ListType):
+                raise CheckError(f"[{fn_id}] 'list_get' requires list, got {list_type}")
+            index_type = self._check_expr(fn_id, expr.get("index"), env)
+            if not isinstance(index_type, IntType):
+                raise CheckError(f"[{fn_id}] 'list_get.index' must be int, got {index_type}")
+            return list_type.inner
+
+        elif op == "list_push":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise CheckError(f"[{fn_id}] 'list_push.list' must be a variable reference")
+            list_type = self._check_expr(fn_id, list_expr, env)
+            if not isinstance(list_type, ListType):
+                raise CheckError(f"[{fn_id}] 'list_push' requires list, got {list_type}")
+            value_type = self._check_expr(fn_id, expr.get("value"), env)
+            if not types_equal(value_type, list_type.inner):
+                raise CheckError(
+                    f"[{fn_id}] 'list_push.value' type mismatch: expected {list_type.inner}, got {value_type}"
+                )
+            return UnitType()
+
+        elif op == "list_len":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise CheckError(f"[{fn_id}] 'list_len.list' must be a variable reference")
+            list_type = self._check_expr(fn_id, list_expr, env)
+            if not isinstance(list_type, ListType):
+                raise CheckError(f"[{fn_id}] 'list_len' requires list, got {list_type}")
+            return IntType(bits=64, overflow="panic")
+
+        elif op == "map_get":
+            map_expr = expr.get("map")
+            if not isinstance(map_expr, dict) or "ref" not in map_expr:
+                raise CheckError(f"[{fn_id}] 'map_get.map' must be a variable reference")
+            map_type = self._check_expr(fn_id, map_expr, env)
+            if not isinstance(map_type, MapType):
+                raise CheckError(f"[{fn_id}] 'map_get' requires map, got {map_type}")
+            key_type = self._check_expr(fn_id, expr.get("key"), env)
+            if not types_equal(key_type, map_type.key):
+                raise CheckError(
+                    f"[{fn_id}] 'map_get.key' type mismatch: expected {map_type.key}, got {key_type}"
+                )
+            return map_type.value
 
         elif op == "ok":
             # Result::Ok constructor — returns _ResultOkIntermediate for return-site checking

--- a/interpreter/runtime.py
+++ b/interpreter/runtime.py
@@ -6,7 +6,7 @@ Executes validated NAIL programs.
 from typing import Any
 from .types import (
     IntType, FloatType, BoolType, StringType, UnitType, OptionType,
-    NailRuntimeError, parse_type, types_equal,
+    NailRuntimeError, NailTypeError, parse_type, types_equal,
 )
 
 
@@ -157,6 +157,10 @@ class Runtime:
             self._eval_op(stmt, env)
             return _CONTINUE
 
+        elif op == "list_push":
+            self._eval_op(stmt, env)
+            return _CONTINUE
+
         elif op == "if":
             cond = self._eval(stmt["cond"], env)
             branch = stmt["then"] if cond else stmt["else"]
@@ -277,6 +281,66 @@ class Runtime:
             if not isinstance(l, str) or not isinstance(r, str):
                 raise NailRuntimeError(f"'concat' requires two strings, got {type(l)}, {type(r)}")
             return l + r
+
+        # Collection ops (v0.4)
+        elif op == "list_get":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise NailTypeError("'list_get.list' must be a variable reference")
+            list_val = self._eval(list_expr, env)
+            index = self._eval(expr.get("index"), env)
+            if not isinstance(list_val, list):
+                raise NailTypeError(f"'list_get' requires list value, got {type(list_val).__name__}")
+            if not isinstance(index, int) or isinstance(index, bool):
+                raise NailTypeError(f"'list_get.index' must be int, got {type(index).__name__}")
+            if index < 0 or index >= len(list_val):
+                raise NailRuntimeError(f"'list_get' index out of bounds: {index} (len={len(list_val)})")
+            return list_val[index]
+
+        elif op == "list_push":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise NailTypeError("'list_push.list' must be a variable reference")
+            list_name = list_expr["ref"]
+            if list_name not in env:
+                raise NailRuntimeError(f"Undefined variable: {list_name}")
+            list_val = env[list_name]
+            if not isinstance(list_val, list):
+                raise NailTypeError(f"'list_push' requires list value, got {type(list_val).__name__}")
+            value = self._eval(expr.get("value"), env)
+            if list_val and type(value) is not type(list_val[0]):
+                raise NailTypeError(
+                    f"'list_push.value' type mismatch: expected {type(list_val[0]).__name__}, got {type(value).__name__}"
+                )
+            list_val.append(value)
+            return UNIT
+
+        elif op == "list_len":
+            list_expr = expr.get("list")
+            if not isinstance(list_expr, dict) or "ref" not in list_expr:
+                raise NailTypeError("'list_len.list' must be a variable reference")
+            list_val = self._eval(list_expr, env)
+            if not isinstance(list_val, list):
+                raise NailTypeError(f"'list_len' requires list value, got {type(list_val).__name__}")
+            return len(list_val)
+
+        elif op == "map_get":
+            map_expr = expr.get("map")
+            if not isinstance(map_expr, dict) or "ref" not in map_expr:
+                raise NailTypeError("'map_get.map' must be a variable reference")
+            map_val = self._eval(map_expr, env)
+            key = self._eval(expr.get("key"), env)
+            if not isinstance(map_val, dict):
+                raise NailTypeError(f"'map_get' requires map value, got {type(map_val).__name__}")
+            if map_val:
+                sample_key = next(iter(map_val.keys()))
+                if type(key) is not type(sample_key):
+                    raise NailTypeError(
+                        f"'map_get.key' type mismatch: expected {type(sample_key).__name__}, got {type(key).__name__}"
+                    )
+            if key not in map_val:
+                raise NailRuntimeError(f"'map_get' key not found: {key!r}")
+            return map_val[key]
 
         elif op == "ok":
             return NailResult("ok", self._eval(expr["val"], env))

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -43,6 +43,8 @@ INT64 = {"type": "int", "bits": 64, "overflow": "panic"}
 BOOL_T = {"type": "bool"}
 STR_T = {"type": "string"}
 UNIT_T = {"type": "unit"}
+LIST_INT = {"type": "list", "inner": INT64, "len": "dynamic"}
+MAP_STR_INT = {"type": "map", "key": STR_T, "value": INT64}
 
 
 def fn_spec(fn_id, params, returns, body, effects=None):
@@ -615,6 +617,85 @@ class TestStringOps(unittest.TestCase):
         ])
         result = run_spec(spec)
         self.assertEqual(result, "false")
+
+
+class TestCollectionOpsV04(unittest.TestCase):
+
+    def test_list_get_happy(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "return", "val": {"op": "list_get", "list": {"ref": "xs"}, "index": {"lit": 1}}}
+        ])
+        result = run_spec(spec, args={"xs": [10, 20, 30]})
+        self.assertEqual(result, 20)
+
+    def test_list_push_happy(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "list_push", "list": {"ref": "xs"}, "value": {"lit": 7}},
+            {"op": "return", "val": {"op": "list_len", "list": {"ref": "xs"}}},
+        ])
+        result = run_spec(spec, args={"xs": [1, 2]})
+        self.assertEqual(result, 3)
+
+    def test_list_len_happy(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "return", "val": {"op": "list_len", "list": {"ref": "xs"}}}
+        ])
+        result = run_spec(spec, args={"xs": [1, 2, 3, 4]})
+        self.assertEqual(result, 4)
+
+    def test_map_get_happy(self):
+        spec = fn_spec("f", [{"id": "m", "type": MAP_STR_INT}], INT64, [
+            {"op": "return", "val": {"op": "map_get", "map": {"ref": "m"}, "key": {"lit": "answer"}}}
+        ])
+        result = run_spec(spec, args={"m": {"answer": 42}})
+        self.assertEqual(result, 42)
+
+    def test_list_get_empty_list_raises(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "return", "val": {"op": "list_get", "list": {"ref": "xs"}, "index": {"lit": 0}}}
+        ])
+        Checker(spec).check()
+        with self.assertRaises(NailRuntimeError):
+            Runtime(spec).run({"xs": []})
+
+    def test_list_get_out_of_bounds_raises(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "return", "val": {"op": "list_get", "list": {"ref": "xs"}, "index": {"lit": 2}}}
+        ])
+        Checker(spec).check()
+        with self.assertRaises(NailRuntimeError):
+            Runtime(spec).run({"xs": [1]})
+
+    def test_list_push_type_mismatch_checker_raises(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], UNIT_T, [
+            {"op": "list_push", "list": {"ref": "xs"}, "value": {"lit": "bad"}},
+            {"op": "return", "val": {"lit": None, "type": UNIT_T}},
+        ])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_map_get_key_type_mismatch_checker_raises(self):
+        spec = fn_spec("f", [{"id": "m", "type": MAP_STR_INT}], INT64, [
+            {"op": "return", "val": {"op": "map_get", "map": {"ref": "m"}, "key": {"lit": 1}}}
+        ])
+        with self.assertRaises(CheckError):
+            Checker(spec).check()
+
+    def test_list_len_runtime_type_mismatch_raises_nail_type_error(self):
+        spec = fn_spec("f", [{"id": "xs", "type": LIST_INT}], INT64, [
+            {"op": "return", "val": {"op": "list_len", "list": {"ref": "xs"}}}
+        ])
+        Checker(spec).check()
+        with self.assertRaises(NailTypeError):
+            Runtime(spec).run({"xs": "not-a-list"})
+
+    def test_map_get_runtime_key_type_mismatch_raises_nail_type_error(self):
+        spec = fn_spec("f", [{"id": "m", "type": MAP_STR_INT}], INT64, [
+            {"op": "return", "val": {"op": "map_get", "map": {"ref": "m"}, "key": {"lit": "x"}}}
+        ])
+        Checker(spec).check()
+        with self.assertRaises(NailTypeError):
+            Runtime(spec).run({"m": {1: 100}})
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Closes #26

Implements operational logic for list and map types that were defined in the SPEC but had no corresponding operations in checker/runtime.

## New Operations
- `list_get`: index into list → element type; out-of-bounds → NailRuntimeError
- `list_push`: append to list (mutates); value type must match element type
- `list_len`: returns int length
- `map_get`: lookup by key; key type must match declared key type

## Changes
- **checker.py**: type checking for all 4 ops with full type validation
- **runtime.py**: runtime implementations with proper error handling
- **SPEC.md**: Collection Operations section added
- **tests**: happy path, empty collection, out-of-bounds, type mismatch

## Test Results
114 tests passing (was 104).