### PR TITLE
fix: runtime generic alias args support (#74)

### DIFF
--- a/interpreter/runtime.py
+++ b/interpreter/runtime.py
@@ -759,6 +759,33 @@ class Runtime:
                 )
         return result
 
+    @staticmethod
+    def _substitute_params_in_spec(spec: dict, subst: dict[str, dict]) -> dict:
+        """Substitute type-param placeholders in a raw type spec dict.
+
+        Replaces any ``{"type": "param", "name": "T"}`` nodes with the
+        concrete type dict from ``subst[T]``.  Used when instantiating
+        generic type aliases (Issue #74).
+        """
+        if not isinstance(spec, dict):
+            return spec
+        if spec.get("type") == "param":
+            name = spec.get("name", "")
+            if name in subst:
+                return subst[name]
+        result: dict = {}
+        for k, v in spec.items():
+            if isinstance(v, dict):
+                result[k] = Runtime._substitute_params_in_spec(v, subst)
+            elif isinstance(v, list):
+                result[k] = [
+                    Runtime._substitute_params_in_spec(i, subst) if isinstance(i, dict) else i
+                    for i in v
+                ]
+            else:
+                result[k] = v
+        return result
+
     def _resolve_alias_spec(
         self,
         alias_name: str,
@@ -767,17 +794,43 @@ class Runtime:
         cache: dict[str, dict],
         stack: list[str],
         module_id: str,
+        type_args: list[dict] | None = None,
     ) -> dict:
-        if alias_name in cache:
-            return cache[alias_name]
-        if alias_name in stack:
-            cycle = " -> ".join(stack + [alias_name])
-            raise NailRuntimeError(f"Circular type alias detected in module '{module_id}': {cycle}")
         if alias_name not in aliases:
             raise NailRuntimeError(f"Unknown type alias '{alias_name}' in module '{module_id}'")
         alias_spec = aliases[alias_name]
         if not isinstance(alias_spec, dict):
             raise NailRuntimeError(f"Type alias '{alias_name}' in module '{module_id}' must be a type dict")
+
+        type_params: list[str] = alias_spec.get("type_params") or []
+        is_generic = bool(type_params)
+
+        if is_generic:
+            # Generic alias — requires concrete type args; never cached.
+            provided = type_args or []
+            if len(provided) != len(type_params):
+                raise NailRuntimeError(
+                    f"Generic alias '{alias_name}' requires {len(type_params)} type argument(s), "
+                    f"got {len(provided)}"
+                )
+            subst = {type_params[i]: provided[i] for i in range(len(type_params))}
+            # Strip type_params from body spec before substitution/resolution
+            body_spec = {k: v for k, v in alias_spec.items() if k != "type_params"}
+            body_spec = Runtime._substitute_params_in_spec(body_spec, subst)
+            return self._resolve_type_spec(
+                body_spec,
+                aliases=aliases,
+                cache=cache,
+                stack=stack + [alias_name],
+                module_id=module_id,
+            )
+
+        # Non-generic path: use cache and cycle detection.
+        if alias_name in cache:
+            return cache[alias_name]
+        if alias_name in stack:
+            cycle = " -> ".join(stack + [alias_name])
+            raise NailRuntimeError(f"Circular type alias detected in module '{module_id}': {cycle}")
         resolved = self._resolve_type_spec(
             alias_spec,
             aliases=aliases,
@@ -804,12 +857,19 @@ class Runtime:
             alias_name = type_spec.get("name")
             if not isinstance(alias_name, str) or not alias_name:
                 raise NailRuntimeError("Alias type requires non-empty string field 'name'")
+            # Resolve type args (if any) for generic alias instantiation (#74)
+            raw_args = type_spec.get("args") or []
+            resolved_args = [
+                self._resolve_type_spec(a, aliases=aliases, cache=cache, stack=stack, module_id=module_id)
+                for a in raw_args
+            ] if raw_args else None
             return self._resolve_alias_spec(
                 alias_name,
                 aliases=aliases,
                 cache=cache,
                 stack=stack,
                 module_id=module_id,
+                type_args=resolved_args,
             )
         if t == "option" and "inner" in type_spec:
             resolved = dict(type_spec)

--- a/tests/test_runtime_generic_aliases.py
+++ b/tests/test_runtime_generic_aliases.py
@@ -1,0 +1,276 @@
+"""Tests for generic alias resolution in the Runtime (Issue #74).
+
+Verifies that runtime._resolve_type_spec handles the
+{"type": "alias", "name": "X", "args": [...]} form the same way
+checker._resolve_type_spec does.
+
+Covers:
+- typed-null (lit:null with a generic alias type annotation)
+- typed variables bound with generic alias types
+- single-param and two-param generic aliases at runtime
+- option/list/map generic alias instantiation
+- checker and runtime agree on resolved types
+"""
+
+import pytest
+from interpreter import Checker, Runtime, CheckError
+from interpreter.runtime import UNIT
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+INT64 = {"type": "int", "bits": 64, "overflow": "panic"}
+STRING = {"type": "string"}
+BOOL_T = {"type": "bool"}
+UNIT_T = {"type": "unit"}
+
+
+def make_module(types: dict, fns: list) -> dict:
+    return {
+        "nail": "0.7.1",
+        "kind": "module",
+        "id": "test_runtime_generic",
+        "exports": [f["id"] for f in fns],
+        "types": types,
+        "defs": fns,
+    }
+
+
+def make_fn(fn_id, params, returns, body, effects=None):
+    return {
+        "nail": "0.7.1",
+        "kind": "fn",
+        "id": fn_id,
+        "effects": effects or [],
+        "params": params,
+        "returns": returns,
+        "body": body,
+    }
+
+
+def run_fn(spec, fn_id, args=None):
+    """Check + run a function; raise on checker or runtime errors."""
+    Checker(spec).check()
+    rt = Runtime(spec)
+    return rt.run_fn(fn_id, args or {})
+
+
+# ── typed-null with generic alias ─────────────────────────────────────────────
+
+class TestTypedNullWithGenericAlias:
+    """lit:null annotated with a generic alias type must work at runtime."""
+
+    def test_maybe_typed_null_returns_none(self):
+        """fn returns null typed as Maybe<int> (option<int64>) at runtime."""
+        mod = make_module(
+            types={
+                "Maybe": {
+                    "type_params": ["T"],
+                    "type": "option",
+                    "inner": {"type": "param", "name": "T"},
+                }
+            },
+            fns=[make_fn(
+                "nothing",
+                params=[],
+                returns={"type": "alias", "name": "Maybe", "args": [INT64]},
+                body=[{
+                    "op": "return",
+                    "val": {
+                        "lit": None,
+                        "type": {"type": "alias", "name": "Maybe", "args": [INT64]},
+                    },
+                }],
+            )],
+        )
+        result = run_fn(mod, "nothing")
+        assert result is None
+
+    def test_maybe_typed_null_string(self):
+        """fn returns null typed as Maybe<string> at runtime."""
+        mod = make_module(
+            types={
+                "Maybe": {
+                    "type_params": ["T"],
+                    "type": "option",
+                    "inner": {"type": "param", "name": "T"},
+                }
+            },
+            fns=[make_fn(
+                "no_string",
+                params=[],
+                returns={"type": "alias", "name": "Maybe", "args": [STRING]},
+                body=[{
+                    "op": "return",
+                    "val": {
+                        "lit": None,
+                        "type": {"type": "alias", "name": "Maybe", "args": [STRING]},
+                    },
+                }],
+            )],
+        )
+        result = run_fn(mod, "no_string")
+        assert result is None
+
+
+# ── let binding with generic alias type annotation ────────────────────────────
+
+class TestLetBindingGenericAlias:
+    """Variables declared with generic alias type annotations work at runtime."""
+
+    def test_bag_of_int_let_binding(self):
+        """type Bag[T] = list<T>; fn uses Bag<int> in a let binding."""
+        mod = make_module(
+            types={
+                "Bag": {
+                    "type_params": ["T"],
+                    "type": "list",
+                    "inner": {"type": "param", "name": "T"},
+                    "len": "dynamic",
+                }
+            },
+            fns=[make_fn(
+                "bag_len",
+                params=[{
+                    "id": "xs",
+                    "type": {"type": "alias", "name": "Bag", "args": [INT64]},
+                }],
+                returns=INT64,
+                body=[{
+                    "op": "return",
+                    "val": {"op": "list_len", "list": {"ref": "xs"}},
+                }],
+            )],
+        )
+        result = run_fn(mod, "bag_len", {"xs": [1, 2, 3]})
+        assert result == 3
+
+    def test_pair_map_passthrough(self):
+        """type Pair[A,B] = map<A,B>; fn accepts and returns a Pair<string,int>."""
+        mod = make_module(
+            types={
+                "Pair": {
+                    "type_params": ["A", "B"],
+                    "type": "map",
+                    "key": {"type": "param", "name": "A"},
+                    "value": {"type": "param", "name": "B"},
+                }
+            },
+            fns=[make_fn(
+                "passthrough",
+                params=[{
+                    "id": "p",
+                    "type": {"type": "alias", "name": "Pair", "args": [STRING, INT64]},
+                }],
+                returns={"type": "alias", "name": "Pair", "args": [STRING, INT64]},
+                body=[{"op": "return", "val": {"ref": "p"}}],
+            )],
+        )
+        data = {"a": 1, "b": 2}
+        result = run_fn(mod, "passthrough", {"p": data})
+        assert result == data
+
+
+# ── checker/runtime agreement ─────────────────────────────────────────────────
+
+class TestCheckerRuntimeAgreement:
+    """Checker and Runtime produce consistent results for generic alias usages."""
+
+    def test_option_wrapper_checker_and_runtime_agree(self):
+        """Checker passes; runtime returns None for typed-null with generic alias."""
+        mod = make_module(
+            types={
+                "Opt": {
+                    "type_params": ["T"],
+                    "type": "option",
+                    "inner": {"type": "param", "name": "T"},
+                }
+            },
+            fns=[make_fn(
+                "get_none",
+                params=[],
+                returns={"type": "alias", "name": "Opt", "args": [BOOL_T]},
+                body=[{
+                    "op": "return",
+                    "val": {
+                        "lit": None,
+                        "type": {"type": "alias", "name": "Opt", "args": [BOOL_T]},
+                    },
+                }],
+            )],
+        )
+        # Checker must not raise
+        Checker(mod).check()
+        # Runtime must return None (the option-None value)
+        result = Runtime(mod).run_fn("get_none", {})
+        assert result is None
+
+    def test_generic_alias_identity_fn(self):
+        """fn identity(x: NumList<int>) -> NumList<int> returns x unchanged."""
+        mod = make_module(
+            types={
+                "NumList": {
+                    "type_params": ["T"],
+                    "type": "list",
+                    "inner": {"type": "param", "name": "T"},
+                    "len": "dynamic",
+                }
+            },
+            fns=[make_fn(
+                "identity",
+                params=[{
+                    "id": "xs",
+                    "type": {"type": "alias", "name": "NumList", "args": [INT64]},
+                }],
+                returns={"type": "alias", "name": "NumList", "args": [INT64]},
+                body=[{"op": "return", "val": {"ref": "xs"}}],
+            )],
+        )
+        Checker(mod).check()
+        inp = [10, 20, 30]
+        result = Runtime(mod).run_fn("identity", {"xs": inp})
+        assert result == inp
+
+    def test_non_generic_alias_unaffected(self):
+        """Non-generic aliases continue to work normally after the fix."""
+        mod = make_module(
+            types={"UserId": INT64},
+            fns=[make_fn(
+                "make_user",
+                params=[],
+                returns={"type": "alias", "name": "UserId"},
+                body=[{"op": "return", "val": {"lit": 42}}],
+            )],
+        )
+        Checker(mod).check()
+        result = Runtime(mod).run_fn("make_user", {})
+        assert result == 42
+
+    def test_generic_alias_arity_error_at_runtime(self):
+        """Runtime raises when a generic alias is instantiated with wrong arity."""
+        mod = make_module(
+            types={
+                "Box": {
+                    "type_params": ["T"],
+                    "type": "option",
+                    "inner": {"type": "param", "name": "T"},
+                }
+            },
+            fns=[make_fn(
+                "bad",
+                params=[],
+                # Intentionally wrong arity — bypass checker by constructing directly
+                returns={"type": "alias", "name": "Box", "args": [INT64, STRING]},
+                body=[{
+                    "op": "return",
+                    "val": {
+                        "lit": None,
+                        # use a valid concrete type for the lit so runtime evals it
+                        "type": {"type": "option", "inner": INT64},
+                    },
+                }],
+            )],
+        )
+        # Checker should catch the arity mismatch
+        with pytest.raises((CheckError, Exception), match="type argument|GENERIC_ALIAS_ARITY"):
+            Checker(mod).check()


### PR DESCRIPTION
Fixes #74

Runtime alias resolver now handles generic alias args (type substitution), matching checker semantics. Typed-null and other runtime type-parse paths now behave consistently with checked types.