### PR TITLE
fix: skip eager generic alias resolution in imports (#71)

### DIFF
--- a/interpreter/checker.py
+++ b/interpreter/checker.py
@@ -474,6 +474,10 @@ class Checker:
                     raise CheckError(f"Module '{module_id}' has invalid type alias name")
                 if not isinstance(alias_spec, dict):
                     raise CheckError(f"Module '{module_id}' type alias '{alias_name}' must be a type dict")
+                # Generic aliases (have type_params) are resolved lazily at each
+                # instantiation site; skip eager resolution to avoid missing args.
+                if alias_spec.get("type_params"):
+                    continue
                 self._resolve_alias_spec(
                     alias_name,
                     aliases=imported_aliases,

--- a/tests/test_generic_aliases.py
+++ b/tests/test_generic_aliases.py
@@ -1,4 +1,4 @@
-"""Tests for generic type aliases — module-level types with type_params (Issue #62).
+"""Tests for generic type aliases — module-level types with type_params (Issue #62, #71).
 
 Covers:
 - Basic generic alias definition and instantiation
@@ -6,6 +6,7 @@ Covers:
 - Nested generic aliases
 - Generic alias in function signatures
 - Error cases: arity mismatch, unknown param
+- Generic aliases imported from another module (Issue #71)
 """
 
 import pytest
@@ -305,3 +306,150 @@ class TestGenericAliasErrors:
             )]
         )
         check(mod)  # Should not raise
+
+
+# ── Generic aliases via module imports (Issue #71) ────────────────────────────
+
+def _make_generic_lib_module():
+    """A library module that exports generic type aliases."""
+    return {
+        "nail": "0.7.1",
+        "kind": "module",
+        "id": "generic_lib",
+        "exports": ["wrap"],
+        "types": {
+            "Box": {
+                "type_params": ["T"],
+                "type": "option",
+                "inner": {"type": "param", "name": "T"},
+            },
+            "Pair": {
+                "type_params": ["A", "B"],
+                "type": "map",
+                "key": {"type": "param", "name": "A"},
+                "value": {"type": "param", "name": "B"},
+            },
+            # Non-generic alias in same module — must still be eagerly resolved
+            "Name": {"type": "string"},
+        },
+        "defs": [
+            {
+                "nail": "0.7.1",
+                "kind": "fn",
+                "id": "wrap",
+                "effects": [],
+                "params": [{"id": "x", "type": INT64}],
+                "returns": {"type": "option", "inner": INT64},
+                "body": [
+                    {
+                        "op": "return",
+                        "val": {"lit": None, "type": {"type": "option", "inner": INT64}},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class TestImportedGenericAliases:
+    """Issue #71: _process_imports() must skip eager resolution for generic aliases.
+
+    Before the fix, importing a module that contained a generic alias (one with
+    ``type_params``) caused _resolve_alias_spec() to be called without the
+    required ``type_args``, resulting in a spurious GENERIC_ALIAS_ARITY error
+    at import time rather than at instantiation sites.
+    """
+
+    def _check_with_lib(self, caller_spec):
+        """Run checker with generic_lib pre-loaded as an external module."""
+        c = Checker(caller_spec, modules={"generic_lib": _make_generic_lib_module()})
+        c.check()
+        return c
+
+    def test_import_module_with_generic_alias_does_not_crash(self):
+        """Importing a module that has a generic alias should not raise at import time."""
+        caller = {
+            "nail": "0.7.1",
+            "kind": "module",
+            "id": "caller",
+            "imports": [{"module": "generic_lib", "fns": ["wrap"]}],
+            "exports": ["main"],
+            "defs": [
+                make_fn(
+                    "main",
+                    params=[],
+                    returns={"type": "unit"},
+                    effects=[],
+                    body=[{"op": "return", "val": {"lit": None, "type": {"type": "unit"}}}],
+                )
+            ],
+        }
+        self._check_with_lib(caller)  # Must not raise
+
+    def test_import_module_with_multiple_generic_aliases_does_not_crash(self):
+        """Importing a module with multiple generic aliases (1-param and 2-param) should not raise."""
+        # This specifically tests Issue #71: before the fix, _process_imports() called
+        # _resolve_alias_spec() for every alias including generic ones, which crashed
+        # because generic aliases require type_args at instantiation time.
+        caller = {
+            "nail": "0.7.1",
+            "kind": "module",
+            "id": "caller",
+            "imports": [{"module": "generic_lib", "fns": ["wrap"]}],
+            "exports": ["main"],
+            "defs": [
+                make_fn(
+                    "main",
+                    params=[{"id": "n", "type": INT64}],
+                    returns={"type": "option", "inner": INT64},
+                    effects=[],
+                    body=[
+                        {
+                            "op": "return",
+                            "val": {
+                                "op": "call",
+                                "fn": "wrap",
+                                "module": "generic_lib",
+                                "args": [{"ref": "n"}],
+                            },
+                        }
+                    ],
+                )
+            ],
+        }
+        self._check_with_lib(caller)  # Must not raise (regression for Issue #71)
+
+    def test_imported_module_non_generic_alias_still_eagerly_resolved(self):
+        """Non-generic aliases in an imported module are still eagerly resolved (cache populated)."""
+        caller = {
+            "nail": "0.7.1",
+            "kind": "module",
+            "id": "caller",
+            "imports": [{"module": "generic_lib", "fns": ["wrap"]}],
+            "exports": [],
+            "defs": [],
+        }
+        c = self._check_with_lib(caller)
+        # "Name" is a non-generic alias — it must have been resolved into the cache
+        assert "Name" in c._module_alias_spec_cache.get("generic_lib", {}), (
+            "Non-generic alias 'Name' should be eagerly resolved into the module alias spec cache"
+        )
+
+    def test_imported_module_generic_alias_skipped_in_cache(self):
+        """Generic aliases from an imported module are NOT in the eager-resolve cache."""
+        caller = {
+            "nail": "0.7.1",
+            "kind": "module",
+            "id": "caller",
+            "imports": [{"module": "generic_lib", "fns": ["wrap"]}],
+            "exports": [],
+            "defs": [],
+        }
+        c = self._check_with_lib(caller)
+        cache = c._module_alias_spec_cache.get("generic_lib", {})
+        assert "Box" not in cache, (
+            "Generic alias 'Box' should be skipped (not eagerly resolved) in the import cache"
+        )
+        assert "Pair" not in cache, (
+            "Generic alias 'Pair' should be skipped (not eagerly resolved) in the import cache"
+        )


### PR DESCRIPTION
Fixes #71

In _process_imports(), generic aliases (those with type_params) are now skipped during eager resolution. They are resolved lazily at instantiation sites, consistent with main-module behavior.